### PR TITLE
Rubocop fix

### DIFF
--- a/recipes/application_php.rb
+++ b/recipes/application_php.rb
@@ -32,7 +32,7 @@ include_recipe 'phpstack::php_fpm'
 include_recipe 'chef-sugar'
 
 # if gluster is in our environment, install the utils and mount it to /var/www
-if node.deep_fetch['rackspace_gluster']['config']['server']['glusters'].values[0].has_key?('nodes')
+if node.deep_fetch['rackspace_gluster']['config']['server']['glusters'].values[0].key?('nodes')
   if Chef::Config[:solo]
     Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
   else


### PR DESCRIPTION
Fix:

recipes/application_php.rb:35:83: C: Hash#has_key? is deprecated in favor of Hash#key?.
