### PR TITLE
service test uses 'service name status' which is still different across ...

### DIFF
--- a/test/integration/mysql-master/serverspec/default_spec.rb
+++ b/test/integration/mysql-master/serverspec/default_spec.rb
@@ -6,15 +6,19 @@ if os[:family] == 'RedHat'
   describe service('mysqld') do
     it { should be_enabled }
   end
+  describe service('mysqld') do
+    it { should be_running }
+  end
 else
   describe service('mysql') do
     it { should be_enabled }
   end
+  describe service('mysql') do
+    it { should be_running }
+  end
 end
 
-describe service('mysqld') do
-  it { should be_running }
-end
+
 
 describe port(3306) do
   it { should be_listening }


### PR DESCRIPTION
...centos/ubuntu
