### PR TITLE
Add NewRelic monitoring recipe for PHP Agent

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license 'Apache 2.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 description 'Provides a full php stack'
 
-version '0.0.7'
+version '0.0.8'
 
 depends 'apache2', '~> 1.10'
 depends 'application'
@@ -23,6 +23,7 @@ depends 'memcached'
 depends 'mongodb'
 depends 'mysql'
 depends 'mysql-multi'
+depends 'newrelic'
 depends 'openssl'
 depends 'php'
 depends 'php-fpm'

--- a/recipes/newrelic.rb
+++ b/recipes/newrelic.rb
@@ -1,0 +1,25 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: phpstack
+# Recipe:: newrelic
+#
+# Copyright 2014, Rackspace Hosting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The node['newrelic']['license'] attribute needs to be set for NewRelic to work
+
+node.override['newrelic']['application_monitoring']['daemon']['ssl'] = true
+node.override['newrelic']['server_monitoring']['ssl'] = true
+include_recipe 'newrelic::php-agent'


### PR DESCRIPTION
New Relic is included in platformstack when a license key attribute is set. This makes sure SSL is on and installs the PHP agent for NewRelic.
