### PR TITLE
Add check for NewRelic license key

### DIFF
--- a/recipes/newrelic.rb
+++ b/recipes/newrelic.rb
@@ -24,4 +24,5 @@ fail 'The NewRelic license attribute is not set.' if node['newrelic']['license']
 
 node.override['newrelic']['application_monitoring']['daemon']['ssl'] = true
 node.override['newrelic']['server_monitoring']['ssl'] = true
+node.override['newrelic']['php-agent']['agent_action'] = 'upgrade'
 include_recipe 'newrelic::php-agent'


### PR DESCRIPTION
Just make sure the license key is set and fail if it isn't. The recipe for the agent won't work anyway (if the license is not set) because of dependency in platformstack:

``` ruby
run_context.include_recipe('newrelic::default') unless node['newrelic']['license'].nil?
```
