### PR TITLE
Apache 2.4 support, closes #63

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,9 @@ platforms:
   - name: ubuntu-12.04
     run_list:
     - recipe[apt]
+  - name: ubuntu-14.04
+    run_list:
+    - recipe[apt]
   - name: centos-6.5
     run_list:
     - recipe[yum]

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://api.berkshelf.com"
+source 'https://api.berkshelf.com'
 
 cookbook 'logstash_stack', git: 'git@github.com:rackspace-cookbooks/logstash_stack.git'
 cookbook 'rackspace_iptables', git: 'git@github.com:rackspace-cookbooks/rackspace_iptables.git'
@@ -10,8 +10,6 @@ cookbook 'cron', git: 'git@github.com:rackspace-cookbooks/cron.git'
 cookbook 'pg-multi', git: 'git@github.com:rackspace-cookbooks/pg-multi.git'
 
 group :integration do
-#  cookbook 'phpstack_test_app', path: 'test/fixtures/cookbooks/phpstack_test_app'
-
   cookbook 'apt'
   cookbook 'yum'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,9 +7,9 @@ license 'Apache 2.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 description 'Provides a full php stack'
 
-version '0.0.8'
+version '0.0.9'
 
-depends 'apache2', '~> 1.10'
+depends 'apache2'
 depends 'application'
 depends 'application_php'
 depends 'apt'

--- a/templates/default/apache2/sites/example.com.erb
+++ b/templates/default/apache2/sites/example.com.erb
@@ -7,8 +7,12 @@
   <Directory <%= @params[:docroot] %>>
     Options <%= [@params[:directory_options] || "FollowSymLinks" ].flatten.join " " %>
     AllowOverride <%= [@params[:allow_override] || "None" ].flatten.join " " %>
+    <% if node['apache']['version'] == '2.2' -%>
     Order allow,deny
     Allow from all
+    <% elsif node['apache']['version'] == '2.4' -%>
+    Require all granted
+    <% end -%>
   </Directory>
 
   <Directory />
@@ -19,9 +23,13 @@
   <Location /server-status>
     SetHandler server-status
 
+    <% if node['apache']['version'] == '2.2' -%>
     Order Deny,Allow
     Deny from all
     Allow from 127.0.0.1
+    <% elsif node['apache']['version'] == '2.4' -%>
+    Require host 127.0.0.1
+    <% end -%>
   </Location>
 
   LogLevel info
@@ -33,8 +41,12 @@
   <% end -%>
 
   RewriteEngine On
+  <% if node['apache']['version'] == '2.2' -%>
   RewriteLog <%= node['apache']['log_dir'] %>/<%= @application_name %>-rewrite.log
   RewriteLogLevel 0
+  <% elsif node['apache']['version'] == '2.4' -%>
+  LogLevel alert rewrite:trace1
+  <% end -%>
 
   # DO NOT canonicalize example.com's template
   # Canonical host, <%= @params[:server_name] %>


### PR DESCRIPTION
This commit removes the lock on the apache2 cookbook now that 2.4 has been merged upstream.
The site template has been updated with logic based on Apache version.

Based on changes listed here: http://httpd.apache.org/docs/2.4/upgrading.html
