### PR TITLE
Adding mongo client

### DIFF
--- a/attributes/php.rb
+++ b/attributes/php.rb
@@ -45,3 +45,9 @@ when 'debian'
 end
 
 default['phpstack']['ini']['cookbook'] = 'phpstack'
+
+if node['platform_version'].to_f <= 14.04
+  default['php']['ext_conf_dir']  = '/etc/php5/cli/conf.d'
+else
+  default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
+end

--- a/recipes/application_php.rb
+++ b/recipes/application_php.rb
@@ -38,7 +38,7 @@ else
 end
 
 # Adding mongod compatibility
-php_pear "mongo" do
+php_pear 'mongo' do
   action :install
 end
 

--- a/recipes/mysql_base.rb
+++ b/recipes/mysql_base.rb
@@ -105,8 +105,8 @@ unless includes_recipe?('phpstack::mysql_slave')
       node['apache']['sites'][site_name]['databases'].each do |database|
         database = database[0]
         mysql_password = node['apache']['sites'][site_name]['databases'][database]['mysql_password']
-        if mysql_password.nil? or mysql_password.empty? or !node['apache']['sites'][site_name]['databases'][database]['mysql_password']
-          mysql_password = secure_password 
+        if mysql_password.nil? || mysql_password.empty? || !node['apache']['sites'][site_name]['databases'][database]['mysql_password']
+          mysql_password = secure_password
         end
 
         mysql_database_user node['apache']['sites'][site_name]['databases'][database]['mysql_user'] do


### PR DESCRIPTION
Adding mongo driver as part of the application_php recipe
Moving php and php::ini recipes out of the apache clause, otherwise if webserver is nginx pecl won't work 
