### PR TITLE
Making rubocop not run on the Guardfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 # Rubocop,  we're buddies and all,  but we're going to have to disagree on the following -
 
+# Disable for Guardfile
+AllCops:
+  Exclude:
+    - 'Guardfile'
+
 # Disable requirement of "encoding" headers on files
 Encoding:
   Enabled: false


### PR DESCRIPTION
Signed-off-by: Matthew Thode mthode@mthode.org
