### PR TITLE
Fixes #227 - Varnish attribute set to array instead of hash

### DIFF
--- a/attributes/varnish.rb
+++ b/attributes/varnish.rb
@@ -18,4 +18,4 @@
 #
 
 default['phpstack']['varnish']['multi'] = true
-default['phpstack']['varnish']['backend_nodes'] = []
+default['phpstack']['varnish']['backend_nodes'] = {}


### PR DESCRIPTION
Small change to set the default attribute for:

default[stackname]['varnish']['backend_nodes'] = []

in attributes/varnish.rb to a hash {} instead of array []. This fixes #227.
