### PR TITLE
Revert "Revert "remove static assignment to (dir)/current in templates""

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@
   - if glusterfs is set up via `node['rackspace_gluster']['config']['server']['glusters']` glusterfs will be set up as a client
   - deploys your apps, from attributes, depending on what `node['phpstack']['webserver']` is set to
     - deploys from `node['phpstack'][node['phpstack']['webserver']]['sites']`
+    - deploys under the `node['phpstack'][node['phpstack']['webserver']]['sites'][port][site_name]['deploy_user']` (and group)
+      - uses the web server's group if available and unset (or nobody if not available and unset), overridable
+    - deploys to the location specified in `node['phpstack'][node['phpstack']['webserver']]['sites'][port][site_name]['docbase']`
+      - docroot defaults to the docbase location + /current (so /var/www/site/port/current by default)
   - creates a `/etc/phpstack.ini` file with authentication info for the other nodes in the environment
     - only finding mysql and rabbitmq nodes right now
   - creates a backup job that backs up `/var/www` by default
@@ -276,6 +280,8 @@ shouldn't really be messed with
         "sites": {
           80: {
             "example.com": {
+              "deploy_user": "foo",
+              "deploy_group": "bar",
               "template": "apache2/sites/example.com-80.erb",
               "cookbook": "phpstack",
               "server_name": "example.com",
@@ -283,7 +289,8 @@ shouldn't really be messed with
                 "www.example.com",
                 "test.example.com"
               ],
-              "docroot": "/var/www/example.com/80",
+              "docbase": "/var/www/example.com/80",
+              "docroot": "/var/www/example.com/80/current",
               "errorlog": "/var/log/apache/example.com-error.log",
               "customlog": "/var/log/apache/example.com-access.log combined",
               "allow_override": [

--- a/recipes/application_php.rb
+++ b/recipes/application_php.rb
@@ -93,9 +93,9 @@ if node.deep_fetch(stackname, 'code-deployment', 'enabled')
     sites.each do |site_name, site_opts|
       next if site_opts['repository'] == ''
       application "#{site_name}-#{port}" do
-        path site_opts['docroot']
-        owner node[node[stackname]['webserver']]['user']
-        group node[node[stackname]['webserver']]['group']
+        path site_opts['docbase']
+        owner site_opts['deploy_user']
+        group site_opts['deploy_group']
         deploy_key site_opts['deploy_key']
         repository site_opts['repository']
         revision site_opts['revision']

--- a/recipes/default_unless.rb
+++ b/recipes/default_unless.rb
@@ -28,6 +28,8 @@ node.default_unless[stackname][node[stackname]['webserver']]['sites'] = {}
 # server specific stuff
 node[stackname][node[stackname]['webserver']]['sites'].each do |port, sites|
   sites.each do |site_name, site_opts|
+    node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['deploy_user'] = node[node[stackname]['webserver']]['user']
+    node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['deploy_group'] = node[node[stackname]['webserver']]['group']
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['revision'] = 'master'
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['repository'] = ''
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['deploy_key'] = '/root/.ssh/id_rsa'
@@ -35,7 +37,9 @@ node[stackname][node[stackname]['webserver']]['sites'].each do |port, sites|
     next unless %w(apache nginx).include?(node[stackname]['webserver'])
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['cookbook'] = stackname
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['server_alias'] = []
-    node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['docroot'] = "/var/www/#{site_name}/#{port}"
+    node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['docbase'] = "/var/www/#{site_name}/#{port}"
+    node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['docroot'] =
+      "#{node[stackname][node[stackname]['webserver']]['sites'][port][site_name]['docbase']}/current"
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['monitoring_hostname'] = site_name
     node.default_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['customlog'] =
       "#{node[node[stackname]['webserver']]['log_dir']}/#{site_name}-#{port}-access.log combined"

--- a/templates/default/apache2/sites/example.com.erb
+++ b/templates/default/apache2/sites/example.com.erb
@@ -1,7 +1,7 @@
 <VirtualHost *:<%= @params[:port] || node['apache']['listen_ports'].first %>>
   ServerName <%= @params[:server_aliases].first %>:<%= @params[:port] %>
   ServerAlias <% @params[:server_aliases].each do |a| %><%= a %> <% end %>
-  DocumentRoot <%= @params[:docroot] %>/current
+  DocumentRoot <%= @params[:docroot] %>
   RewriteEngine On
 
   <Directory <%= @params[:docroot] %>>

--- a/templates/default/nginx/sites/example.com.erb
+++ b/templates/default/nginx/sites/example.com.erb
@@ -1,7 +1,7 @@
 server {
   listen <%= @port %>;
   server_name <% @server_aliases.each do |a| %><%= a %> <% end %>;
-  root <%= @docroot %>/current;
+  root <%= @docroot %>;
 
   location / {
     index  index.html index.htm index.php;


### PR DESCRIPTION
This reverts commit 412f3acbd3b0977ac0d5d88510ea64e7ec90f353.

This should be a major version bump

* Allows the setting of user/group to be separate from the web server user/group
* Separates the location for the deployed code and the http server's docroot

Signed-off-by: Matthew Thode <mthode@mthode.org>