### PR TITLE
Added site_name to the parmeters being passed to the nginx vhost template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 phpstack CHANGELOG
 ==================
 
+4.0.3
+------
+* @lil-cain - Added site_name to variables for nginx templates
+
 4.0.2
 ------
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 # long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 description 'Provides a full php stack'
-version '4.0.3'
+version '4.0.4'
 
 depends 'apache2', '>= 3.0.1'
 depends 'application', '>= 4.1.6'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -64,7 +64,8 @@ node[stackname]['nginx']['sites'].each do |port, sites|
         server_aliases: site_opts['server_alias'].empty? ? [site_name] : site_opts['server_alias'],
         docroot: site_opts['docroot'],
         errorlog: site_opts['errorlog'],
-        customlog: site_opts['customlog']
+        customlog: site_opts['customlog'],
+        site_name: site_name
       )
       notifies :reload, 'service[nginx]'
     end


### PR DESCRIPTION
This is useful as we have a use case where we want one php-fpm pool per site.
Unfortunately neither server_name nor site_name is passed on to the template,
which makes using this difficult.
